### PR TITLE
fix bug in predicting with KNN models for :brutetree algorithm and metric.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ MLJModelInterface = "^0.3.5, ^0.4, 1.0"
 NearestNeighbors = "^0.4"
 StatsBase = "^0.33"
 Tables = "^1.2"
-julia = "1"
+julia = "1.3"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/src/NearestNeighborModels.jl
+++ b/src/NearestNeighborModels.jl
@@ -61,14 +61,15 @@ const KNNCoreFields = """
         [Distances.jl](https://github.com/JuliaStats/Distances.jl) for the 
         distance between points. For `algorithm = :kdtree` only metrics which are of 
         type `$(NN.MinkowskiMetric)` are supported.
-    * `leafsize::Int = algorithm == :brutetree ? 0 : 10` : determines the number of points 
-        at which to stop splitting the tree. This option doesn't apply to `:brutetree` 
-        algorithm, since `brutetree` isn't actually a tree.
-    * `reorder::Bool = algorithm != :brutetree` : if `true` then points which are close in 
+    * `leafsize::Int = algorithm == 10` : determines the number of points 
+        at which to stop splitting the tree. This option is ignored and always taken as `0` 
+        for `algorithm = :brutetree`, since `brutetree` isn't actually a tree.
+    * `reorder::Bool = true` : if `true` then points which are close in 
         distance are placed close in memory. In this case, a copy of the original data 
         will be made so that the original data is left unmodified. Setting this to `true` 
         can significantly improve performance of the specified `algorithm` 
-        (except `:brutetree`).
+        (except `:brutetree`). This option is ignored and always taken as `false` for 
+        `algorithm = :brutetree`.
     * `weights::KNNKernel=Uniform()` : kernel used in assigning weights to the 
         k-nearest neighbors for each observation. An instance of one of the types in 
         `list_kernels()`. User-defined weighting functions can be passed by wrapping the 

--- a/src/NearestNeighborModels.jl
+++ b/src/NearestNeighborModels.jl
@@ -1,6 +1,6 @@
 module NearestNeighborModels
 
-# ===================================================================
+# ==============================================================================================
 # IMPORTS
 import MLJModelInterface
 import MLJModelInterface: @mlj_model, metadata_model, metadata_pkg,
@@ -14,12 +14,12 @@ using FillArrays
 using LinearAlgebra
 using Statistics
 
-# ===================================================================
+# ==============================================================================================
 ## EXPORTS
 export list_kernels, ColumnTable, DictTable
 
 # Export KNN models
-# KNN models are exported automatically by `@mjl_model`
+export KNNClassifier, KNNRegressor, MultitargetKNNClassifier, MultitargetKNNRegressor
 
 # Re-Export Distance Metrics from `Distances.jl`
 export Euclidean, Cityblock, Minkowski, Chebyshev, Hamming, WeightedEuclidean,
@@ -29,7 +29,7 @@ export Euclidean, Cityblock, Minkowski, Chebyshev, Hamming, WeightedEuclidean,
 export DualU, DualD, Dudani, Fibonacci, Inverse, ISquared, KNNKernel, Macleod, Rank,
     ReciprocalRank, UDK, Uniform, UserDefinedKernel, Zavreal
 
-# ===================================================================
+# ===============================================================================================
 ## CONSTANTS
 const Vec{T} = AbstractVector{T}
 const Mat{T} = AbstractMatrix{T}
@@ -57,9 +57,18 @@ const KNNClassifierDescription = """
 const KNNCoreFields = """
     * `K::Int=5` : number of neighbors
     * `algorithm::Symbol = :kdtree` : one of `(:kdtree, :brutetree, :balltree)`
-    * `metric::Metric = Euclidean()` : a `Metric` object for the distance between points
-    * `leafsize::Int = 10` : at what number of points to stop splitting the tree
-    * `reorder::Bool = true` : if true puts points close in distance close in memory
+    * `metric::Metric = Euclidean()` : any `Metric` from 
+        [Distances.jl](https://github.com/JuliaStats/Distances.jl) for the 
+        distance between points. For `algorithm = :kdtree` only metrics which are of 
+        type `$(NN.MinkowskiMetric)` are supported.
+    * `leafsize::Int = algorithm == :brutetree ? 0 : 10` : determines the number of points 
+        at which to stop splitting the tree. This option doesn't apply to `:brutetree` 
+        algorithm, since `brutetree` isn't actually a tree.
+    * `reorder::Bool = algorithm != :brutetree` : if `true` then points which are close in 
+        distance are placed close in memory. In this case, a copy of the original data 
+        will be made so that the original data is left unmodified. Setting this to `true` 
+        can significantly improve performance of the specified `algorithm` 
+        (except `:brutetree`).
     * `weights::KNNKernel=Uniform()` : kernel used in assigning weights to the 
         k-nearest neighbors for each observation. An instance of one of the types in 
         `list_kernels()`. User-defined weighting functions can be passed by wrapping the 
@@ -101,19 +110,19 @@ const KNNFields = """
     
     """
 
-# ===================================================================
+# ==============================================================================================
 # Includes
 include("utils.jl")
 include("kernels.jl")
 include("models.jl")
     
-# ===================================================================
+# ===============================================================================================
 # List of all models interfaced
 const MODELS = (
     KNNClassifier, KNNRegressor, MultitargetKNNRegressor, MultitargetKNNClassifier
 )
 
-# ====================================================================
+# ===============================================================================================
 # PKG_METADATA
 metadata_pkg.(
     MODELS,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using NearestNeighborModels
+using Distances
 using StableRNGs
 using Test
 using MLJBase
@@ -8,10 +9,18 @@ import NearestNeighborModels: check_onebased_indexing, combine_weights,
     err_if_given_invalid_K, Fill, get_weights, KNNResult, NeighDistsMatrix,
     NeighIndsMatrix, RankOneMatrix, _replace!, scale, sort_idxs, _sum
 
+const NN = NearestNeighborModels.NearestNeighbors
+
 include("testutils.jl")
 
-@testset "NearestNeighborModels.jl" begin
-    include("models.jl")
-    include("utils.jl")
-    include("kernels.jl")
+@testset verbose=true "NearestNeighborModels.jl" begin
+    @testset "models" begin
+        include("models.jl")
+    end
+    @testset "utils" begin
+        include("utils.jl")
+    end
+    @testset "kernels" begin
+        include("kernels.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ const NN = NearestNeighborModels.NearestNeighbors
 
 include("testutils.jl")
 
-@testset verbose=true "NearestNeighborModels.jl" begin
+@testset "NearestNeighborModels.jl" begin
     @testset "models" begin
         include("models.jl")
     end


### PR DESCRIPTION
```julia
julia> using MLJ, NearestNeighborModels, DataFrames

julia> X_rand = rand(50,3);

julia> coef = [1; 0; 1];

julia> y_rand = X_rand*coef + rand(50,1);

julia> X_rand_df = DataFrames.DataFrame(X_rand, :auto) #convert to dataframe for MLJ inputs

julia> y_rand_df = DataFrames.DataFrame(y_rand, :auto);

julia> train_idx, test_idx = partition(eachindex(y_rand_df[:,1]), 0.7, shuffle=true);

julia> tree1 = KNNRegressor(algorithm=:brutetree, metric= Euclidean(), reorder = false, leafsize=0)
KNNRegressor(
    K = 5,
    algorithm = :brutetree,
    metric = Euclidean(0.0),
    leafsize = 0,
    reorder = false,
    weights = Uniform())

julia> tree2 = KNNRegressor(algorithm=:brutetree, metric= Cityblock(), reorder = false, leafsize=0)
KNNRegressor(
    K = 5,
    algorithm = :brutetree,
    metric = Cityblock(),
    leafsize = 0,
    reorder = false,
    weights = Uniform())

julia> tree3 = KNNRegressor(algorithm=:brutetree)
KNNRegressor(
    K = 5,
    algorithm = :brutetree,
    metric = Euclidean(0.0),
    leafsize = 0,
    reorder = false,
    weights = Uniform())

julia> mach1 = machine(tree1,  X_rand_df[train_idx, :], y_rand_df[train_idx, 1]);

julia> mach2 = machine(tree2,  X_rand_df[train_idx, :], y_rand_df[train_idx, 1]);

julia> mach3 = machine(tree3,  X_rand_df[train_idx, :], y_rand_df[train_idx, 1]);

julia> fit!(mach1)
[ Info: Training Machine{KNNRegressor,…}.
Machine{KNNRegressor,…} trained 1 time; caches data
  model: KNNRegressor
  args:
    1:  Source @344 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @234 ⏎ `AbstractVector{Continuous}`


julia> fit!(mach2)
[ Info: Training Machine{KNNRegressor,…}.
Machine{KNNRegressor,…} trained 1 time; caches data
  model: KNNRegressor
  args:
    1:  Source @582 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @640 ⏎ `AbstractVector{Continuous}`

julia> fit!(mach3)
[ Info: Training Machine{KNNRegressor,…}.
Machine{KNNRegressor,…} trained 1 time; caches data
  model: KNNRegressor
  args:
    1:  Source @492 ⏎ `Table{AbstractVector{Continuous}}`
    2:  Source @836 ⏎ `AbstractVector{Continuous}`

julia> preds1 = MLJ.predict(mach1, X_rand_df[test_idx,:]);

julia> preds2 = MLJ.predict(mach2, X_rand_df[test_idx,:]);

julia> preds1 == preds2
false

julia> preds3 = MLJ.predict(mach3, X_rand_df[test_idx,:])
15-element Vector{Float64}:
 1.7029412653743503
 1.4591779632945534
 1.582290743528469
 2.101230332732603
 2.2316740656510454
 1.4370807503964989
 1.70609816653188
 1.5000572634358513
 1.6903333540586924
 1.5000572634358516
 1.5193869250110221
 1.0055116437574894
 1.1873231287446022
 1.3289743625868122
 1.1843582933771475
```
closes #46, closes #45.

